### PR TITLE
Add workflow to deploy documentation to Github Pages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,6 @@ trim_trailing_whitespace = false
 insert_final_newline = false
 
 [*.yaml]
+indent_size = 2
 [*.yml]
 indent_size = 2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,36 @@
+name: Build and Publish Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - docs/**
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
### Description:

This PR adds a workflow to build and deploy the documentation to Github Pages. The workflow followed this [doc](https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions).

### Checklist:
* [x] Tests passing (`go test -timeout=5m ./...`)?
* [x] Lint passing (`golangci-lint run -c .golangci.yaml`)? This requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation)
* [x] Basic security test passing (`semgrep scan . --exclude=readme.md`)? This requires [semgrep](https://semgrep.dev/docs/getting-started/quickstart)
